### PR TITLE
Fix typo in the required package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "joomla/framework": "~3.0"
+        "joomlatools/framework": "~3.0"
     },
     "extra": {
         "joomlatools-component": "activities"


### PR DESCRIPTION
This will fix the typo in the required package name for joomlatools/framework.